### PR TITLE
Delete commented line in Embed message

### DIFF
--- a/.github/workflows/discord-push.yml
+++ b/.github/workflows/discord-push.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Run Discord Webhook
         uses: Mist3r-Robot/classic-discord-webhook@main
         with:
@@ -20,9 +20,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: Dependencies

--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ You can see the example file at [/.github/workflows/discord-push.yml](/.github/w
 | **Required** — This is the id of your Discord webhook, if you copy the webhook url, this will be the first part of it. | **Required** — Your Discord webhook token, it's the second part of the url. | Not required — if you want to send the message in a thread, you can specify the thread id here. |
 
 
-### Need more help ? [See this post on DEV](https://dev.to/mrrobot/follow-your-repository-from-discord-52ge)
-
-[![Badge forked from](https://img.shields.io/badge/Forked-from%20Slimefun%2Fdiscordwebhook-black?logo=GitHub&style=for-the-badge)](https://github.com/Slimefun/discord-webhook)
-
+> **Note**
+>
+> Need more help ? [See this post on DEV](https://dev.to/mrrobot/follow-your-repository-from-discord-52ge) or [this post on my blog in French](https://thomasbnt.dev/blog/robot-discord-basique/).
+> [![follow your repository from Discord - Post on DEV](https://user-images.githubusercontent.com/14293805/198847774-bd7b38e7-5b61-4723-99a1-e767babac3a5.png)](https://dev.to/mrrobot/follow-your-repository-from-discord-52ge)
 
 ### Notable documentations
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
     - name: Run Discord Webhook
       uses: Mist3r-Robot/classic-discord-webhook@main
       with:
@@ -41,9 +41,9 @@ jobs:
 You can see the example file at [/.github/workflows/discord-push.yml](/.github/workflows/discord-push.yml)
 ## Inputs
 
-| `id` | `token` |
-|:-----------:|:----------------------------------------------------------:|
-| **Required** — This is the id of your Discord webhook, if you copy the webhook url, this will be the first part of it. | **Required** — Your Discord webhook token, it's the second part of the url. |
+| `id` | `token` | `in_thread`|
+|:-----------:|:----------------------------------------------------------:|:----------------------------------------------------------:|
+| **Required** — This is the id of your Discord webhook, if you copy the webhook url, this will be the first part of it. | **Required** — Your Discord webhook token, it's the second part of the url. | Not required — if you want to send the message in a thread, you can specify the thread id here. |
 
 
 ### Need more help ? [See this post on DEV](https://dev.to/mrrobot/follow-your-repository-from-discord-52ge)

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   token:
     description: The Discord Webhook Token
     required: true
+  in_thread:
+    description: If you want to send the embed message in a specific thread
+    required: false
 
 runs:
   using: 'node16'

--- a/src/discord.js
+++ b/src/discord.js
@@ -25,7 +25,6 @@ function createEmbed(repo, branch, url, commits, size) {
     console.log(latest)
     return new MessageEmbed()
         .setColor(0x00bb22)
-        //.setTitle(size + (size == 1 ? " Commit was " : " Commits were ") + "added to " + repo + " (" + branch + ")")
         .setAuthor({
             name: `${size} ${size === 1 ? 'commit was ' : 'commits were'} added to ${branch}`,
             iconURL: `https://github.com/${latest.author.username}.png?size=32`,

--- a/src/discord.js
+++ b/src/discord.js
@@ -1,12 +1,22 @@
 const {MessageEmbed, WebhookClient} = require("discord.js")
 const MAX_MESSAGE_LENGTH = 40
 
-module.exports.send = (id, token, repo, branch, url, commits, size) =>
+module.exports.send = (id, token, repo, branch, url, commits, size, in_thread) =>
     new Promise((resolve, reject) => {
         let client
         console.log('Preparing Webhook...')
         try {
-            client = new WebhookClient({id: id, token: token})
+            // If in_thread is empty, ignore
+            if (in_thread === '' || in_thread === null) {
+                client = new WebhookClient({id: id, token: token})
+            } else {
+                client = new WebhookClient({
+                    id: id,
+                    token: token,
+                    // If in_thread is not empty, use it as the thread ID
+                    threadId: in_thread
+                })
+            }            
         } catch (error) {
             console.log('Error creating Webhook')
             reject(error.message)

--- a/src/index.js
+++ b/src/index.js
@@ -17,9 +17,10 @@ async function run() {
 
   const id = core.getInput('id')
   const token = core.getInput('token')
+  const in_thread = core.getInput('in_thread')
 
   webhook
-    .send(id, token, repository, branch, payload.compare, commits, size)
+    .send(id, token, repository, branch, payload.compare, commits, size, in_thread)
     .catch((err) => core.setFailed(err.message))
 }
 


### PR DESCRIPTION
## Description

- Adding `in_thread` option on webhook, permit to send into a thread the embed message.
- Delete a commented line in the embed messages
- Updated `core/checkout` and `actions/setup-node` to **v3** because Node v12 isn't any more available on GitHub
- Added note to the post on DEV (English version) and on my personal blog (French version)


## Link(s) to resource(s)

- https://discord.js.org/#/docs/main/stable/class/WebhookClient?scrollTo=options
- https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12