### PR TITLE
Migrate GitHub Action to Node v20

### DIFF
--- a/.github/workflows/discord-push.yml
+++ b/.github/workflows/discord-push.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x]
 
     steps:
       - name: Checkout

--- a/src/discord.js
+++ b/src/discord.js
@@ -66,7 +66,7 @@ function createEmbed (repo, branch, url, commits, size) {
     .setURL(url)
     .setAuthor({
       name: `${size} ${
-        size === 1 ? 'commit was ' : 'commits were'
+        size === 1 ? 'commit was' : 'commits were'
       } added to ${branch}`,
       iconURL: latest.author.avatar,
     })


### PR DESCRIPTION
> Node 16 has reached its [end of life](https://github.com/nodejs/Release/#end-of-life-releases), prompting us to initiate its deprecation process for GitHub Actions. Our plan is to transition all actions to run on Node 20 by Spring 2024. We will actively monitor the migration's progress and gather community feedback before finalizing the transition date. Starting October 23rd, workflows containing actions running on Node 16 will display a warning to alert users about the upcoming migration.

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/