### PR TITLE
Rename action to 'Send Discord message' and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 [![GitHub Marketplace](https://img.shields.io/badge/Marketplace-Classic%20Discord%20Webhook-2088FF?style=flat-square&logo=github-actions&logoColor=white)](https://github.com/marketplace/actions/classic-discord-webhook) [![GitHub Sponsors](https://img.shields.io/badge/Sponsor-%23EA54AE?style=flat-square&logo=github-sponsors&logoColor=white)](https://github.com/sponsors/thomasbnt) [![License: GPL-3.0](https://img.shields.io/badge/License-GPL--3.0-blue?style=flat-square)](./LICENSE)
 
-![Classic Discord Webhook — light](docs/classic_discord_webhook.png#gh-light-mode-only)
-![Classic Discord Webhook — dark](docs/classic_discord_webhook-dark.png#gh-dark-mode-only)
+![Classic Discord Webhook](docs/classic_discord_webhook.png)
 
 > A GitHub Action that sends a clean, structured Discord notification on every push — using Discord **Components v2**.
 

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Classic Discord Webhook'
+name: 'Send Discord message'
 description: 'Send a formatted Discord notification on every push — commit links, branch, author, and changelog using Discord Components v2.'
 branding:
   icon: git-commit


### PR DESCRIPTION
This pull request updates the project branding and documentation to better reflect its functionality and improve clarity for users. The most important changes are:

Branding and naming updates:
* Changed the `name` field in `action.yml` from `'Classic Discord Webhook'` to `'Send Discord message'` to more clearly describe the action's purpose.

Documentation improvements:
* Updated the `README.md` image to use a single, non-theme-specific screenshot for simplicity and consistency.